### PR TITLE
fix(ubuntu): correct script execution order in dev.sh

### DIFF
--- a/ubuntu/dev.sh
+++ b/ubuntu/dev.sh
@@ -3,12 +3,12 @@
 
 NAME=${1:-ubuntu-24}
 
-./auth-doppler.sh
-./build-image.sh $NAME
 
 if [ "$(docker ps -aq -f name=$NAME)" ]; then
     echo "Container with the same name detected before this script run. Consider stopping and removing the container..."
 else
+    ./auth-doppler.sh
+    ./build-image.sh $NAME
     doppler run --command="./run_container.sh $NAME $NAME"
 fi
 


### PR DESCRIPTION
- Moved `auth-doppler.sh` and `build-image.sh` execution inside the conditional block in `dev.sh`, avoiding unnecessary image build and authentication