### PR TITLE
fix(zsh): initialize SCRIPT_SOURCED variable

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,3 +1,7 @@
+if [ -z "$SCRIPT_SOURCED" ]; then
+    export SCRIPT_SOURCED=0
+fi
+
 cd() {
     builtin cd "$@"
     if [[ ("$(pwd)" == "/Users/uxjp/dev" || "$(pwd)" == /Users/uxjp/dev/*) && "$SCRIPT_SOURCED" -ne 1 ]]; then


### PR DESCRIPTION
Added initialization for the SCRIPT_SOURCED variable to ensure it is set to 0 if not already defined. This prevents potential issues when sourcing scripts in the /Users/uxjp/dev directory and its subdirectories.